### PR TITLE
Add schema domain entities and configure EF Core persistence

### DIFF
--- a/src/servers/Web/Daas.Api/Controllers/MockController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/MockController.cs
@@ -1,0 +1,59 @@
+﻿using Daas.Api.Storage;
+using Daas.Application.Users.Queries;
+using Daas.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Dynamic;
+
+namespace Daas.Api.Controllers;
+
+[ApiController]
+[Route("mock")]
+public class MockController : ControllerBase
+{
+    private readonly FieldGeneratorFactory _factory;
+    private readonly AppDbContext _context;
+
+    public MockController(FieldGeneratorFactory factory, AppDbContext context)
+    {
+        _factory = factory;
+        _context = context;
+    }
+    [HttpGet("{id}")]
+    public IActionResult GetMockData(Guid id)
+    {
+        var schema = _context.Schemas
+            .Include(x => x.Fields)
+            .FirstOrDefault(x => x.Id == id);
+
+        if (schema == null)
+        {
+            return NotFound();
+        }
+
+        int howmany = 10;
+
+        var result = new List<object>();
+
+        for (int i = 0; i < howmany; i++)
+        {
+            var row =
+                new ExpandoObject()
+                as IDictionary<string, object>;
+
+            foreach (var field in schema.Fields)
+            {
+                var value =
+                    _factory
+                        .Get((FieldType)field.FieldType)
+                        .Generator();
+
+                row.Add(field.FieldName, value);
+            }
+
+            result.Add(row);
+        }
+
+        return Ok(result);
+    }
+}

--- a/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
@@ -1,0 +1,41 @@
+﻿using Daas.Api.Storage;
+using Daas.Application.DTO.RequestDTO;
+using Daas.Application.Users.Queries;
+using Daas.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections;
+using System.Dynamic;
+using Microsoft.EntityFrameworkCore;
+using Daas.Infrastructure.Persistence;
+
+namespace Daas.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SchemaController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly FieldGeneratorFactory factory;
+    private readonly AppDbContext _context;
+
+    public SchemaController(IMediator mediator, FieldGeneratorFactory _factory, AppDbContext context)
+    {
+        _mediator = mediator;
+        factory = _factory;
+        _context = context;
+    }
+    [HttpPost]
+    public IActionResult CreateSchema([FromBody] Schema schema)
+    {
+        schema.Id = Guid.NewGuid();
+
+        _context.Schemas.Add(schema);
+        _context.SaveChanges();
+
+        return Ok(new
+        {
+            schema.Id
+        });
+    }
+}

--- a/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
@@ -38,4 +38,19 @@ public class SchemaController : ControllerBase
             schema.Id
         });
     }
+
+    [HttpGet("{id}")]
+    public IActionResult GetSchema(Guid id)
+    {
+        var schema = _context.Schemas
+            .Include(x => x.Fields)
+            .FirstOrDefault(x => x.Id == id);
+
+        if (schema == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(schema);
+    }
 }

--- a/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/SchemaController.cs
@@ -53,4 +53,42 @@ public class SchemaController : ControllerBase
 
         return Ok(schema);
     }
+
+    [HttpGet("{id}/data/{howmany}")]
+    public IActionResult GenerateData(
+        Guid id,
+        int howmany)
+    {
+        var schema = _context.Schemas
+            .Include(x => x.Fields)
+            .FirstOrDefault(x => x.Id == id);
+
+        if (schema == null)
+        {
+            return NotFound();
+        }
+
+        var result = new List<object>();
+
+        for (int i = 0; i < howmany; i++)
+        {
+            var row =
+                new ExpandoObject()
+                as IDictionary<string, object>;
+
+            foreach (var field in schema.Fields)
+            {
+                var value =
+    factory
+        .Get((Daas.Application.Users.Queries.FieldType)field.FieldType)
+        .Generator();
+
+                row.Add(field.FieldName, value);
+            }
+
+            result.Add(row);
+        }
+
+        return Ok(result);
+    }
 }

--- a/src/servers/Web/Daas.Api/Storage/InMemorySchemaStore.cs
+++ b/src/servers/Web/Daas.Api/Storage/InMemorySchemaStore.cs
@@ -1,0 +1,8 @@
+﻿using Daas.Domain.Entities;
+namespace Daas.Api.Storage;
+
+public static class InMemorySchemaStore
+{
+    public static Dictionary<Guid, Schema> Schemas
+        = new();
+}

--- a/src/servers/Web/Daas.Application/ENUMS/FieldTypes.cs
+++ b/src/servers/Web/Daas.Application/ENUMS/FieldTypes.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Daas.Application.ENUMS
+{
+    public enum FieldTypes
+    {
+        INT,
+        FLOAT,
+        DOUBLE,
+        DECIMAL,
+        CHAR,
+        STRING,
+        BOOLEAN,
+        DATE,
+        TIME,
+        DATETIME,
+        GUID,
+        UUID,
+        BYTE,
+        SHORT,
+        USHORT,
+        LONG,
+        LONGLONG,
+        ULONG,
+        SBYTE,
+        BINARY
+    }
+}

--- a/src/servers/Web/Daas.Domain/Entities/FieldDefinition.cs
+++ b/src/servers/Web/Daas.Domain/Entities/FieldDefinition.cs
@@ -1,0 +1,16 @@
+﻿using Daas.Domain.Entities;
+using System.Text.Json.Serialization;
+
+public class FieldDefinition
+{
+    public int Id { get; set; }
+
+    public string FieldName { get; set; } = string.Empty;
+
+    public FieldTypes FieldType { get; set; }
+
+    public Guid SchemaId { get; set; }
+
+    [JsonIgnore]
+    public Schema? Schema { get; set; }
+}

--- a/src/servers/Web/Daas.Domain/Entities/FieldTypes.cs
+++ b/src/servers/Web/Daas.Domain/Entities/FieldTypes.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Daas.Domain.Entities;
+
+public enum FieldTypes
+{
+    INT,
+    FLOAT,
+    DOUBLE,
+    DECIMAL,
+    CHAR,
+    STRING,
+    BOOLEAN,
+    DATE,
+    TIME,
+    DATETIME,
+    GUID,
+    UUID,
+    BYTE,
+    SHORT,
+    USHORT,
+    LONG,
+    LONGLONG,
+    ULONG,
+    SBYTE,
+    BINARY
+}

--- a/src/servers/Web/Daas.Domain/Entities/Schema.cs
+++ b/src/servers/Web/Daas.Domain/Entities/Schema.cs
@@ -1,0 +1,11 @@
+﻿namespace Daas.Domain.Entities;
+
+public class Schema
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public List<FieldDefinition> Fields { get; set; }
+        = new();
+}

--- a/src/servers/Web/Daas.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/servers/Web/Daas.Infrastructure/Persistence/AppDbContext.cs
@@ -10,7 +10,9 @@ public class AppDbContext : DbContext, IAppDbContext
         : base(options)
     {
     }
+    public DbSet<Schema> Schemas => Set<Schema>();
 
+    public DbSet<FieldDefinition> FieldDefinitions => Set<FieldDefinition>();
     public DbSet<User> Users => Set<User>();
 
     IQueryable<User> IAppDbContext.Users => Users;


### PR DESCRIPTION
Discontinued CQRS Pattern.
Implemented save Schema Logic, now the schemas are saved in sql.
For now mock data generation is possible just by giving schem Id.