### PR TITLE
Add Double field type and generation support in DAAS

### DIFF
--- a/src/servers/Web/Daas.Application/Users/Queries/DoubleGenerator.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/DoubleGenerator.cs
@@ -1,0 +1,16 @@
+﻿using Daas.Application.Users.Queries;
+
+public class DoubleGenerator : IFieldValueGenerator
+{
+    private readonly Random random;
+
+    public DoubleGenerator(Random random)
+    {
+        this.random = random;
+    }
+
+    public object Generator()
+    {
+        return random.NextDouble() * 1000;
+    }
+}

--- a/src/servers/Web/Daas.Application/Users/Queries/FieldGeneratorFactory.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/FieldGeneratorFactory.cs
@@ -24,7 +24,8 @@ namespace Daas.Application.Users.Queries
                 FieldType.Float=> new FloatGenerator(_random),
                 FieldType.Character=> new CharacterGenerator(_random),
                 FieldType.Guid=> new GuidGenerator(),
-                FieldType.Date => new DateGenerator(_random)
+                FieldType.Date => new DateGenerator(_random),
+                FieldType.Double => new DoubleGenerator(_random)
             };
         }
 

--- a/src/servers/Web/Daas.Application/Users/Queries/FieldType.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/FieldType.cs
@@ -6,7 +6,7 @@ namespace Daas.Application.Users.Queries
 {
     public enum FieldType
     {
-        Int,Float,Boolean,String,Character,Guid,Date
+        Int,Float,Boolean,String,Character,Guid,Date,Double
         //"0" = Int,
         //Float,
         //Boolean,


### PR DESCRIPTION
Added support for Double type of Data Generation in the FieldDataGeneratorFactory, Closing Data Generation support types by this. Will be extended Later.